### PR TITLE
Potential fix for https://github.com/ans-group/basebot/issues/12

### DIFF
--- a/packages/basebot-core/dist/applySkills.js
+++ b/packages/basebot-core/dist/applySkills.js
@@ -43,7 +43,7 @@ function _default(_ref) {var channels = _ref.channels,middleware = _ref.middlewa
 
   function defaultResponse(bot, message) {
     if (!message.answered) {
-      bot.reply(message, "Sorry, didn't catch that");
+      bot.reply(message, process.env.defaultResponse || "Sorry, didn't catch that")
     }
   }
 

--- a/packages/basebot-core/src/applySkills.js
+++ b/packages/basebot-core/src/applySkills.js
@@ -43,7 +43,7 @@ export default ({ channels, middleware, logger, skills }) => {
 
   function defaultResponse(bot, message) {
     if (!message.answered) {
-      bot.reply(message, "Sorry, didn't catch that")
+      bot.reply(message, process.env.defaultResponse || "Sorry, didn't catch that")
     }
   }
 


### PR DESCRIPTION
Enable users to configure defaultResponse via environment variables or fallback to "Sorry, didn't catch that" if nothing is set